### PR TITLE
Automatic serializable dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ Your derived class must:
 ## Limitations
 
 * Nested objects must be (1) other objects which inherit from `Serializable` (2) namedtuples or (3) primitive types.
+
+* The serialized representation of objects relies on reserved keywords which cannot be
+in any regular dictionary: `"__name__"`, `"__class__"`, `"__module__"`, `"__jsonkeys__"`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/iskandr/serializable.svg?branch=master)](https://travis-ci.org/iskandr/serializable)
+
 # serializable
 Base class with serialization methods for user-defined Python objects
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,10 @@ helpers.
 
 Your derived class must:
 
-* provide a user-defined `to_dict()` method which returns a dictionary whose keys are strings and whose values are all primitive serializable types (list, dict, int, str, &c).
+* provide a user-defined `to_dict()` method which returns a dictionary.
 
 * The keys of the dictionary returned by `to_dict()` must match the arguments to the `__init__` of your class.
 
 ## Limitations
 
-* Nested objects must also inherit from `Serializable` and must be manually converted
-to serializable types in `to_dict()` and then reconstructed by overriding the class
-method `_reconstruct_nested_objects`.
-
-* Functions defined at the top level of a module can be converted to primtive types with
-`function_to_serializable_representation`, but this helper will fail for methods.
+* Nested objects must be (1) other objects which inherit from `Serializable` (2) namedtuples or (3) primitive types.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Your derived class must:
 
 ## Limitations
 
-* Nested objects must be (1) other objects which inherit from `Serializable` (2) namedtuples or (3) primitive types.
+* Serializable objects must inherit from `Serializable`, be tuples or namedtuples, be serializble primitive types such as dict, list, int, float, or str.
 
-* The serialized representation of objects relies on reserved keywords which cannot be
-in any regular dictionary: `"__name__"`, `"__class__"`, `"__module__"`, `"__jsonkeys__"`.
+* The serialized representation of objects relies on reserved keywords (such as `"__name__"`, and `"__class__"`), so dictionaries are expect to not contain any keys which begin with two underscores.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 typechecks >= 0.0.2
 six >= 1.9.0
+simplejson

--- a/serializable/__init__.py
+++ b/serializable/__init__.py
@@ -13,7 +13,12 @@
 from __future__ import print_function, division, absolute_import
 
 from .serializable import Serializable
-from .helpers import to_serializable_repr, from_serializable_repr
+from .helpers import (
+    to_serializable_repr,
+    from_serializable_repr,
+    to_json,
+    from_json,
+)
 
 __version__ = "0.0.4"
 
@@ -21,4 +26,6 @@ __all__ = [
     "Serializable",
     "to_serializable_repr",
     "from_serializable_repr",
+    "to_json",
+    "from_json",
 ]

--- a/serializable/__init__.py
+++ b/serializable/__init__.py
@@ -13,23 +13,12 @@
 from __future__ import print_function, division, absolute_import
 
 from .serializable import Serializable
-from .helpers import (
-    class_from_serializable_representation,
-    class_to_serializable_representation,
-    function_from_serializable_representation,
-    function_to_serializable_representation,
-    object_to_serializable_representation,
-    object_from_serializable_representation,
-)
+from .helpers import to_serializable_repr, from_serializable_repr
 
 __version__ = "0.0.2"
 
 __all__ = [
     "Serializable",
-    "class_from_serializable_representation",
-    "class_to_serializable_representation",
-    "function_from_serializable_representation",
-    "function_to_serializable_representation",
-    "object_to_serializable_representation",
-    "object_from_serializable_representation",
+    "to_serializable_repr",
+    "from_serializable_repr",
 ]

--- a/serializable/__init__.py
+++ b/serializable/__init__.py
@@ -15,7 +15,7 @@ from __future__ import print_function, division, absolute_import
 from .serializable import Serializable
 from .helpers import to_serializable_repr, from_serializable_repr
 
-__version__ = "0.0.2"
+__version__ = "0.0.4"
 
 __all__ = [
     "Serializable",

--- a/serializable/primtive_types.py
+++ b/serializable/primtive_types.py
@@ -17,11 +17,11 @@ be serialized and deserialized successfully.
 from __future__ import print_function, division, absolute_import
 
 from functools import wraps
-from six import text_type, integer_types
+from six import string_types, integer_types
 
 NoneType = type(None)
 
-PRIMITIVE_TYPES = (bool, float, NoneType, text_type) + integer_types
+PRIMITIVE_TYPES = (bool, float, NoneType) + string_types + integer_types
 
 def return_primitive(fn):
     """

--- a/serializable/primtive_types.py
+++ b/serializable/primtive_types.py
@@ -30,7 +30,7 @@ def return_primitive(fn):
     """
     @wraps(fn)
     def wrapped_fn(x):
-        if type(x) in PRIMITIVE_TYPES:
+        if isinstance(x, PRIMITIVE_TYPES):
             return x
         return fn(x)
     return wrapped_fn

--- a/serializable/serializable.py
+++ b/serializable/serializable.py
@@ -13,10 +13,7 @@
 from __future__ import print_function, division, absolute_import
 
 import json
-from .helpers import (
-    object_to_serializable_representation,
-    object_from_serializable_representation,
-)
+from .helpers import from_serializable_repr, to_serializable_repr
 
 class Serializable(object):
     """
@@ -48,12 +45,6 @@ class Serializable(object):
         """
         raise NotImplementedError("Method to_dict() not implemented for %s" % (
             self.__class__.__name__,))
-
-    def _to_serializable_dict(self):
-        d = self.to_dict()
-        for k, v in list(d.items()):
-            d[k] = object_to_serializable_representation(v)
-        return d
 
     def __hash__(self):
         return hash(tuple(sorted(self.to_dict().items())))
@@ -117,32 +108,4 @@ class Serializable(object):
         # I wish I could just return (self.from_dict, (self.to_dict(),) but
         # Python 2 won't pickle the class method from_dict so instead have to
         # use globally defined functions.
-        serializable_repr = object_to_serializable_representation(self)
-        return (
-            object_from_serializable_representation,
-            (serializable_repr,))
-
-
-@return_primitive
-def to_serializable(x):
-    """
-    Convert an instance of Serializable or a primitive collection containing
-    such instances into serializable types.
-    """
-    if isinstance(x, (tuple, list)):
-        return x.__class__([to_serializable(element) for element in x])
-    elif isintance() is dict:
-        return {k: to_serializable(v) for (k, v) in x.items()}
-    elif isinstance(x, Serializable):
-        return to_serializable(x.to_dict())
-
-@return_primitive
-def from_serializable(x):
-    t = type(x)
-    if t in (tuple, list):
-        return t([from_serializable(element) for element in x])
-    elif t is dict:
-        return tk: from_serializable(v) for (k, v) in x.items()}
-    elif isinstance(x, Serializable):
-        return x._to_serializable_dict()
-
+        return (from_serializable_repr, (to_serializable_repr(self),))

--- a/serializable/serializable.py
+++ b/serializable/serializable.py
@@ -43,10 +43,17 @@ class Serializable(object):
         """
         Derived classes must implement this method and return a dictionary
         whose keys match the parameters to __init__. The values must be
-        primitive types (string, int, float, tuple, dict, list).
+        primitive atomic types (bool, string, int, float), primitive
+        collections (int, list, tuple) or instances of Serializable.
         """
         raise NotImplementedError("Method to_dict() not implemented for %s" % (
             self.__class__.__name__,))
+
+    def _to_serializable_dict(self):
+        d = self.to_dict()
+        for k, v in list(d.items()):
+            d[k] = object_to_serializable_representation(v)
+        return d
 
     def __hash__(self):
         return hash(tuple(sorted(self.to_dict().items())))
@@ -114,3 +121,28 @@ class Serializable(object):
         return (
             object_from_serializable_representation,
             (serializable_repr,))
+
+
+@return_primitive
+def to_serializable(x):
+    """
+    Convert an instance of Serializable or a primitive collection containing
+    such instances into serializable types.
+    """
+    if isinstance(x, (tuple, list)):
+        return x.__class__([to_serializable(element) for element in x])
+    elif isintance() is dict:
+        return {k: to_serializable(v) for (k, v) in x.items()}
+    elif isinstance(x, Serializable):
+        return to_serializable(x.to_dict())
+
+@return_primitive
+def from_serializable(x):
+    t = type(x)
+    if t in (tuple, list):
+        return t([from_serializable(element) for element in x])
+    elif t is dict:
+        return tk: from_serializable(v) for (k, v) in x.items()}
+    elif isinstance(x, Serializable):
+        return x._to_serializable_dict()
+

--- a/serializable/serializable.py
+++ b/serializable/serializable.py
@@ -12,8 +12,12 @@
 
 from __future__ import print_function, division, absolute_import
 
-import json
-from .helpers import from_serializable_repr, to_serializable_repr
+from .helpers import (
+    from_serializable_repr,
+    to_serializable_repr,
+    to_json,
+    from_json,
+)
 
 class Serializable(object):
     """
@@ -72,15 +76,14 @@ class Serializable(object):
         """
         Returns a string containing a JSON representation of this Genome.
         """
-        return json.dumps(self.to_dict())
+        return to_json(self)
 
     @classmethod
     def from_json(cls, json_string):
         """
         Reconstruct an instance from a JSON string.
         """
-        state_dict = json.loads(json_string)
-        return cls.from_dict(state_dict)
+        return from_json(json_string)
 
     def write_json_file(self, path):
         """

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ if __name__ == '__main__':
         install_requires=[
             "typechecks>=0.0.2",
             "six>=1.9.0",
+            "simplejson",
         ],
         long_description=readme,
         packages=['serializable'],

--- a/test/test_class.py
+++ b/test/test_class.py
@@ -1,6 +1,6 @@
 from serializable import (
-    class_to_serializable_representation,
-    class_from_serializable_representation,
+    from_serializable_repr,
+    to_serializable_repr
 )
 from nose.tools import eq_
 
@@ -8,12 +8,10 @@ class A(object):
     pass
 
 def test_serialize_custom_class():
-    A_reconstructed = class_from_serializable_representation(
-        class_to_serializable_representation(A))
+    A_reconstructed = from_serializable_repr(to_serializable_repr(A))
     eq_(A, A_reconstructed)
 
 
 def test_serialize_builtin_class():
-    int_reconstructed = class_from_serializable_representation(
-        class_to_serializable_representation(int))
+    int_reconstructed = from_serializable_repr(to_serializable_repr(int))
     eq_(int, int_reconstructed)

--- a/test/test_function.py
+++ b/test/test_function.py
@@ -1,6 +1,6 @@
 from serializable import (
-    function_to_serializable_representation,
-    function_from_serializable_representation,
+    to_serializable_repr,
+    from_serializable_repr,
 )
 from nose.tools import eq_
 
@@ -8,12 +8,10 @@ def global_fn():
     pass
 
 def test_serialize_custom_function():
-    fn_reconstructed = function_from_serializable_representation(
-        function_to_serializable_representation(global_fn))
+    fn_reconstructed = from_serializable_repr(to_serializable_repr(global_fn))
     eq_(global_fn, fn_reconstructed)
 
 
 def test_serialize_builtin_function():
-    fn_reconstructed = function_from_serializable_representation(
-        function_to_serializable_representation(sum))
+    fn_reconstructed = from_serializable_repr(to_serializable_repr(sum))
     eq_(sum, fn_reconstructed)

--- a/test/test_namedtuple.py
+++ b/test/test_namedtuple.py
@@ -1,0 +1,10 @@
+from collections import namedtuple
+from serializable import to_serializable_repr, from_serializable_repr
+from nose.tools import eq_
+
+A = namedtuple("A", "x y")
+
+instance = A(1, 2)
+
+def test_namedtuple_to_json():
+    eq_(instance, from_serializable_repr(to_serializable_repr(instance)))

--- a/test/test_nesting.py
+++ b/test/test_nesting.py
@@ -1,0 +1,25 @@
+from serializable import to_serializable_repr, from_serializable_repr, Serializable
+from nose.tools import eq_
+
+class A(Serializable):
+    def __init__(self, a_val):
+        self.a = a_val
+
+    def to_dict(self):
+        return {"a_val": self.a}
+
+def test_list_of_lists():
+    x = [[1, 2], ["hello", "wookies"], [A(1), A(2)]]
+    eq_(x, from_serializable_repr(to_serializable_repr(x)))
+
+def test_dict_of_lists():
+    x = {"a": [1, 2, 3], "b": ["hello", "goodbye"], "1": [A(1), A(2)]}
+    eq_(x, from_serializable_repr(to_serializable_repr(x)))
+
+def test_dict_with_tuple_keys():
+    x = {(1, 2): "hello"}
+    eq_(x, from_serializable_repr(to_serializable_repr(x)))
+
+def test_object_with_dict_values():
+    x = A(dict(snooze=5))
+    eq_(x, from_serializable_repr(to_serializable_repr(x)))

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -21,8 +21,8 @@ def test_serialize_object_with_helpers():
         to_serializable_repr(instance))
     eq_(instance, instance_reconstructed)
 
-def test_json():
+def test_object_to_json():
     eq_(instance, A.from_json(instance.to_json()))
 
-def test_pickle():
+def test_object_pickle():
     eq_(instance, pickle.loads(pickle.dumps(instance)))

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -1,6 +1,6 @@
 from serializable import (
-    object_to_serializable_representation,
-    object_from_serializable_representation,
+    from_serializable_repr,
+    to_serializable_repr,
     Serializable,
 )
 from nose.tools import eq_
@@ -17,8 +17,8 @@ class A(Serializable):
 instance = A(1, 2)
 
 def test_serialize_object_with_helpers():
-    instance_reconstructed = object_from_serializable_representation(
-        object_to_serializable_representation(instance))
+    instance_reconstructed = from_serializable_repr(
+        to_serializable_repr(instance))
     eq_(instance, instance_reconstructed)
 
 def test_json():

--- a/test/test_primitive_values.py
+++ b/test/test_primitive_values.py
@@ -1,0 +1,17 @@
+from serializable import (
+    from_serializable_repr,
+    to_serializable_repr
+)
+from nose.tools import eq_
+
+def test_int():
+    eq_(1, from_serializable_repr(to_serializable_repr(1)))
+
+def test_float():
+    eq_(1.4, from_serializable_repr(to_serializable_repr(1.4)))
+
+def test_bool():
+    eq_(False, from_serializable_repr(to_serializable_repr(False)))
+
+def test_str():
+    eq_("waffles", from_serializable_repr(to_serializable_repr("waffles")))

--- a/test/test_tuple.py
+++ b/test/test_tuple.py
@@ -1,0 +1,15 @@
+from serializable import (
+    to_serializable_repr,
+    from_serializable_repr,
+    to_json,
+    from_json,
+)
+from nose.tools import eq_
+
+def test_tuple_to_serializable():
+    x = (1, 2.0, "wolves")
+    eq_(x, from_serializable_repr(to_serializable_repr(x)))
+
+def test_tuple_to_json():
+    x = (1, 2.0, "wolves")
+    eq_(x, from_json(to_json(x)))


### PR DESCRIPTION
No longer require definition of manual deserialization logic in each Serializable instance, putting type tags in dictionary representation of all objects. 
