### PR TITLE
Fix serialization of nested sets

### DIFF
--- a/serializable/__init__.py
+++ b/serializable/__init__.py
@@ -21,7 +21,7 @@ from .helpers import (
     to_dict,
 )
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 __all__ = [
     "Serializable",

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -163,7 +163,7 @@ def from_serializable_dict(x):
     if "__class__" in converted_dict:
         class_object = converted_dict.pop("__class__")
         if "__value__" in converted_dict:
-            return class_object(x["__value__"])
+            return class_object(converted_dict["__value__"])
         elif hasattr(class_object, "from_dict"):
             return class_object.from_dict(converted_dict)
         else:

--- a/test/test_nesting.py
+++ b/test/test_nesting.py
@@ -8,6 +8,14 @@ class A(Serializable):
     def to_dict(self):
         return {"a_val": self.a}
 
+class B(Serializable):
+    def __init__(self, set_a_vals=set([A(1), A(2)])):
+        self.set_a_vals = set_a_vals
+
+    def to_dict(self):
+        return {"set_a_vals": self.set_a_vals}
+
+
 def test_list_of_lists():
     x = [[1, 2], ["hello", "wookies"], [A(1), A(2)]]
     eq_(x, from_serializable_repr(to_serializable_repr(x)))
@@ -22,4 +30,8 @@ def test_dict_with_tuple_keys():
 
 def test_object_with_dict_values():
     x = A(dict(snooze=5))
+    eq_(x, from_serializable_repr(to_serializable_repr(x)))
+
+def test_object_with_set_values():
+    x = B()
     eq_(x, from_serializable_repr(to_serializable_repr(x)))


### PR DESCRIPTION
This PR:
- adds a failing test case where classes with `set`s would fail deserialization because it would not load the nested converted classes instead the original serialized values
- fixes that by uses the correct `converted_dict`
- bumps the version.

By the way, this is not deployed automatically in travis. This will be needed for `varcode` as I found this when trying to serialize merged `VariantCollection`s which fail since the variant elements are converted to a `set` in that process.
