### PR TITLE
added hook for updating kwargs before constructing an object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,8 @@ before_install:
 install:
   - >
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-      nose pylint pandoc
+      nose pylint
   - source activate test-environment
-  - pip install pypandoc
   - pip install -r requirements.txt
   - pip install .
   - pip install coveralls

--- a/serializable/__init__.py
+++ b/serializable/__init__.py
@@ -21,7 +21,7 @@ from .helpers import (
     to_dict,
 )
 
-__version__ = "0.1.4"
+__version__ = "0.2.0"
 
 __all__ = [
     "Serializable",

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -194,9 +194,10 @@ def from_serializable_dict(x):
     __name__, __class__, __module__ as metadata about how to reconstruct
     an object.
 
-    TODO: It would be cleaner to always wrap each object in a layer of type
-    metadata and then have an inner dictionary which represents the flattened
-    result of to_dict() for user-defined objects.
+    TODO:
+        It would be cleaner to always wrap each object in a layer of type
+        metadata and then have an inner dictionary which represents the
+        flattened result of to_dict() for user-defined objects.
     """
     if "__name__" in x:
         return _lookup_value(x.pop("__module__"), x.pop("__name__"))

--- a/serializable/serializable.py
+++ b/serializable/serializable.py
@@ -12,6 +12,7 @@
 
 from __future__ import print_function, division, absolute_import
 
+
 from .helpers import (
     from_serializable_repr,
     to_serializable_repr,
@@ -71,7 +72,6 @@ class Serializable(object):
     # None if the keyword has been removed from a class
     _KEYWORD_ALIASES = {}
 
-
     @classmethod
     def _update_kwargs(cls, kwargs):
         """
@@ -80,14 +80,13 @@ class Serializable(object):
         # check every class in the inheritance chain for its own
         # definition of _KEYWORD_ALIASES
         for klass in cls.mro():
-            if hasattr(klass, '_KEYWORD_ALIASES'):
-                for (old_name, new_name) in klass._KEYWORD_ALIASES:
-                    if old_name in kwargs:
-                        old_value = kwargs.pop(old_name)
-                        if new_name and new_name not in kwargs:
-                            kwargs[new_name] = old_value
+            keyword_rename_dict = getattr(klass, '_KEYWORD_ALIASES', {})
+            for (old_name, new_name) in  keyword_rename_dict.items():
+                if old_name in kwargs:
+                    old_value = kwargs.pop(old_name)
+                    if new_name and new_name not in kwargs:
+                        kwargs[new_name] = old_value
         return kwargs
-
 
     @classmethod
     def from_dict(cls, state_dict):

--- a/serializable/serializable.py
+++ b/serializable/serializable.py
@@ -67,11 +67,20 @@ class Serializable(object):
         """
         return state_dict
 
+    # dictionary mapping old keywords to either new names or
+    # None if the keyword has been removed from a class
+    _KEYWORD_ALIASES = {}
+
     @classmethod
     def _update_kwargs(cls, kwargs):
         """
         Rename any old keyword arguments to preserve backwards compatibility
         """
+        for (old_name, new_name) in cls._KEYWORD_ALIASES:
+            if old_name in kwargs:
+                old_value = kwargs.pop(old_name)
+                if new_name and new_name not in kwargs:
+                    kwargs[new_name] = old_value
         return kwargs
 
 

--- a/serializable/serializable.py
+++ b/serializable/serializable.py
@@ -68,13 +68,21 @@ class Serializable(object):
         return state_dict
 
     @classmethod
+    def _update_kwargs(cls, kwargs):
+        """
+        Rename any old keyword arguments to preserve backwards compatibility
+        """
+        return kwargs
+
+
+    @classmethod
     def from_dict(cls, state_dict):
         """
         Given a dictionary of flattened fields (result of calling to_dict()),
         returns an instance.
         """
         state_dict = cls._reconstruct_nested_objects(state_dict)
-        return cls(**state_dict)
+        return cls(**cls._update_kwargs(state_dict))
 
     def to_json(self):
         """

--- a/serializable/serializable.py
+++ b/serializable/serializable.py
@@ -71,16 +71,21 @@ class Serializable(object):
     # None if the keyword has been removed from a class
     _KEYWORD_ALIASES = {}
 
+
     @classmethod
     def _update_kwargs(cls, kwargs):
         """
         Rename any old keyword arguments to preserve backwards compatibility
         """
-        for (old_name, new_name) in cls._KEYWORD_ALIASES:
-            if old_name in kwargs:
-                old_value = kwargs.pop(old_name)
-                if new_name and new_name not in kwargs:
-                    kwargs[new_name] = old_value
+        # check every class in the inheritance chain for its own
+        # definition of _KEYWORD_ALIASES
+        for klass in cls.mro():
+            if hasattr(klass, '_KEYWORD_ALIASES'):
+                for (old_name, new_name) in klass._KEYWORD_ALIASES:
+                    if old_name in kwargs:
+                        old_value = kwargs.pop(old_name)
+                        if new_name and new_name not in kwargs:
+                            kwargs[new_name] = old_value
         return kwargs
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2018. Mount Sinai School of Medicine
+# Copyright (c) 2014-2019. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,14 +30,6 @@ except IOError as e:
     print(e)
     print("Failed to open %s" % readme_path)
 
-try:
-    import pypandoc
-    readme = pypandoc.convert(readme, to='rst', format='md')
-except ImportError as e:
-    print(e)
-    print("Failed to convert %s to reStructuredText", readme_filename)
-    pass
-
 with open('serializable/__init__.py', 'r') as f:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
@@ -53,8 +45,8 @@ if __name__ == '__main__':
         version=version,
         description="Base class with serialization helpers for user-defined Python objects",
         author="Alex Rubinsteyn",
-        author_email="alex.rubinsteyn@mssm.edu",
-        url="https://github.com/openvax/serializable",
+        author_email="alex@openvax.org",
+        url="https://github.com/iskandr/serializable",
         license="http://www.apache.org/licenses/LICENSE-2.0.html",
         classifiers=[
             'Development Status :: 3 - Alpha',
@@ -69,5 +61,6 @@ if __name__ == '__main__':
             "simplejson",
         ],
         long_description=readme,
+        long_description_content_type='text/markdown',
         packages=['serializable'],
     )

--- a/test/test_keyword_aliases.py
+++ b/test/test_keyword_aliases.py
@@ -40,15 +40,18 @@ def test_normal_keywords():
 
 
 def test_removed_keyword():
-    obj = TestClassWithKeywordAliases.from_json(
-            TestClassWithKeywordAliases(x=1, old_gone=2).to_json())
+    d = TestClassWithKeywordAliases(x=1).to_dict()
+    d["old_gone"] = "WILL BE ERASED"
+    obj = TestClassWithKeywordAliases.from_dict(d)
     eq_(obj.x, 1)
     assert not hasattr(obj, "old_gone")
 
 
 def test_removed_keyword_inheritance():
-    obj = DerivedClassWithoutMoreKeywordAliases.from_json(
-            TestClassWithKeywordAliases(x=1, y=2, old_gone=3).to_json())
+    d = DerivedClassWithoutMoreKeywordAliases(x=1, y=2).to_dict()
+    d["old_gone"] = "WILL BE REMOVED"
+
+    obj = DerivedClassWithoutMoreKeywordAliases.from_dict(d)
     eq_(obj.x, 1)
     eq_(obj.y, 2)
     assert not hasattr(obj, "old_gone")

--- a/test/test_keyword_aliases.py
+++ b/test/test_keyword_aliases.py
@@ -1,0 +1,78 @@
+from serializable import Serializable
+from nose.tools import eq_
+
+class TestClassWithKeywordAliases(Serializable):
+    _KEYWORD_ALIASES = {"old_x": "x", "old_gone": None}
+
+    def __init__(self, x):
+        self.x = x
+
+
+class DerivedClassWithMoreKeywordAliases(TestClassWithKeywordAliases):
+    _KEYWORD_ALIASES = {"old_y": "y"}
+
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+class DerivedClassWithoutMoreKeywordAliases(TestClassWithKeywordAliases):
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+def test_normal_keywords():
+    # testing that nothing got screwed in the normal logic of object
+    # serialization/deserialization by the addition of keyword aliases
+    obj1 = TestClassWithKeywordAliases.from_json(
+            TestClassWithKeywordAliases(x=1).to_json())
+    eq_(obj1.x, 1)
+
+    obj2 = DerivedClassWithMoreKeywordAliases.from_json(
+        DerivedClassWithMoreKeywordAliases(x=10, y=20).to_json())
+    eq_(obj2.x, 10)
+    eq_(obj2.y, 20)
+
+    obj3 = DerivedClassWithoutMoreKeywordAliases.from_json(
+        DerivedClassWithoutMoreKeywordAliases(x=100, y=200).to_json())
+    eq_(obj3.x, 100)
+    eq_(obj3.y, 200)
+
+
+def test_removed_keyword():
+    obj = TestClassWithKeywordAliases.from_json(
+            TestClassWithKeywordAliases(x=1, old_gone=2).to_json())
+    eq_(obj.x, 1)
+    assert not hasattr(obj, "old_gone")
+
+
+def test_removed_keyword_inheritance():
+    obj = DerivedClassWithoutMoreKeywordAliases.from_json(
+            TestClassWithKeywordAliases(x=1, y=2, old_gone=3).to_json())
+    eq_(obj.x, 1)
+    eq_(obj.y, 2)
+    assert not hasattr(obj, "old_gone")
+
+
+def test_renamed_keyword():
+    d = TestClassWithKeywordAliases(x=1).to_dict()
+    x = d.pop("x")
+    d["old_x"] = x
+    obj = TestClassWithKeywordAliases.from_dict(d)
+    eq_(obj.x, 1)
+    assert not hasattr(obj, "old_x")
+
+
+def test_renamed_keyword_inheritance():
+    d = DerivedClassWithMoreKeywordAliases(x=1, y=2).to_dict()
+    x = d.pop("x")
+    y = d.pop("y")
+
+    d["old_x"] = x
+    d["old_y"] = y
+
+    obj = DerivedClassWithMoreKeywordAliases.from_dict(d)
+    eq_(obj.x, 1)
+    eq_(obj.y, 2)
+    assert not hasattr(obj, "old_x")
+    assert not hasattr(obj, "old_y")


### PR DESCRIPTION
It seems like `Serializable` creates a lot of trouble if you actually use it to serialize a class and then attempt to deserialze with a later version. If keywords have been renamed or removed then deserialization will fail. This PR adds two ways to update the `kwargs` constructed in `to_dict` before they're passed to a class initializer. If a class just needs to rename or remove some fields, then the class should specify its own `_KEYWORD_ALIASES` dictionary. For example:

```
    _KEYWORD_ALIASES = {'ensembl': 'genome'} 
```

This would rename an old field `ensembl` to `genome` before attempting to construct an object. 

If your class needs more manual control than that it can override the `_update_kwargs` method. 