### PR TITLE
remove usage of external simplejson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pylint>2.0.0,<3.0.0
 typechecks >= 0.0.2,<1.0.0
-simplejson>=3.0.0,<4.0.0

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -14,9 +14,8 @@
 Helper functions for deconstructing classes, functions, and user-defined
 objects into serializable types.
 """
+import json
 from types import FunctionType, BuiltinFunctionType
-
-import simplejson as json
 
 from .primitive_types import return_primitive
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ if __name__ == '__main__':
         ],
         install_requires=[
             "typechecks>=0.0.2",
-            "simplejson",
         ],
         long_description=readme,
         long_description_content_type='text/markdown',


### PR DESCRIPTION
simplejson was a backport of Python3.x 'json' to Python2.

It makes little sense to keep it now.

(I learned that today)